### PR TITLE
update gem google-cloud-pubsub 0.30.0 -> 1.8.0

### DIFF
--- a/fluent-plugin-gcloud-pubsub-custom.gemspec
+++ b/fluent-plugin-gcloud-pubsub-custom.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_runtime_dependency "fluentd", [">= 0.14.15", "< 2"]
-  gem.add_runtime_dependency "google-cloud-pubsub", "~> 0.30.0"
+  gem.add_runtime_dependency "google-cloud-pubsub", "~> 1.8.0"
 
   gem.add_development_dependency "bundler"
   gem.add_development_dependency "rake"


### PR DESCRIPTION
## issue
The following errors often occurs. 
```
error_class=Fluent::GcloudPubSub::RetryableError error="Google api returns error:Google::Cloud::UnavailableError message:14:Deadline Exceeded"
```
it is similar to this issue https://github.com/googleapis/google-cloud-ruby/issues/2322 . so update pubsub gem.

[Latest](https://rubygems.org/gems/google-cloud-pubsub/versions) gem version is 1.8.0

